### PR TITLE
Add dbus config to debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,8 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	dh_auto_install
+	mkdir -p debian/sublogmon/etc/dbus-1/system.d/
+	cp $(CURDIR)/sources/etc/dbus-1/system.d/com.subgraph.sublogmon.conf debian/sublogmon/etc/dbus-1/system.d/
 	rm -rf $(CURDIR)/debian/sublogmon/usr/share/gocode
 
 override_dh_auto_test:


### PR DESCRIPTION
This essentially just mirrors what is done for sublogmon-gui

Before this change, when I did the package build and installed I would get permission errors from dbus when I tried to run sublogmon.

Now when I build and install the deb the file is in place (`/etc/dbus-1/system.d`) and sublogmon launches successfully.